### PR TITLE
explicitly restart kernel to release IPU resources

### DIFF
--- a/learning-PyTorch-on-IPU/efficient_data_loading/walkthrough.ipynb
+++ b/learning-PyTorch-on-IPU/efficient_data_loading/walkthrough.ipynb
@@ -1043,6 +1043,25 @@
     "performance optimisation\n",
     "guide](https://docs.graphcore.ai/projects/memory-performance-optimisation/en/3.0.0/optimising-performance.html#host-ipu-io-optimisation)."
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "99076de7",
+   "metadata": {},
+   "source": [
+    "**Note**: To conclude this notebook, We need to release IPU resources. When using synthetic data, the only way to do that currently is to restart the kernel. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91c92139",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_ipython().kernel.do_shutdown(True)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is needed as a workaround as `detachFromDevice` doesn't work with synthetic data