### PR TITLE
Use kernel overlay

### DIFF
--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -20,10 +20,12 @@ symlink-public-resources() {
     OVERLAY_DIRECTORY="/fusedoverlay"
     if [ ! -d ${OVERLAY_DIRECTORY} ]; then
         echo "Mounting new tmpfs to ${OVERLAY_DIRECTORY}"
+        mkdir -p /fusedoverlay
         mount -t tmpfs tmpfs ${OVERLAY_DIRECTORY}
     fi
     echo "Symlinking - ${public_source_dir} to ${target_dir}"
 
+    mkdir -p ${public_source_dir}
     mkdir -p ${target_dir}
     workdir="${OVERLAY_DIRECTORY}/workdirs/${public_source_dir}"
     upperdir="${OVERLAY_DIRECTORY}/upperdir/${public_source_dir}"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -33,8 +33,8 @@ symlink-public-resources() {
     echo "Symlinking - ${public_source_dir} to ${target_dir}"
 
     mkdir -p ${target_dir}
-    workdir="${OVERLAY_DIRECTORY}/workdirs/${public_source_dir}"
-    upperdir="${OVERLAY_DIRECTORY}/upperdir/${public_source_dir}"
+    workdir="${OVERLAY_DIRECTORY}/workdirs${public_source_dir}"
+    upperdir="${OVERLAY_DIRECTORY}/upperdir${public_source_dir}"
     mkdir -p ${workdir}
     mkdir -p ${upperdir}
     mount -t overlay overlay -o lowerdir=${public_source_dir},upperdir=${upperdir},workdir=${workdir} ${target_dir}

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -24,7 +24,7 @@ symlink-public-resources() {
     fi
     # To use an overlay mount in a container we need to make sure that the
     # work and upper directories are not themselves in overlays.
-    OVERLAY_DIRECTORY="/fusedoverlay"
+    OVERLAY_DIRECTORY="/tmp/fusedoverlay"
     if [ ! -d ${OVERLAY_DIRECTORY} ]; then
         echo "Mounting new tmpfs to ${OVERLAY_DIRECTORY}"
         mkdir -p ${OVERLAY_DIRECTORY}

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -38,7 +38,8 @@ symlink-public-resources() {
     mkdir -p ${workdir}
     mkdir -p ${upperdir}
     mount -t overlay overlay -o lowerdir=${public_source_dir},upperdir=${upperdir},workdir=${workdir} ${target_dir}
-
+    find ${target_dir} -type d -print0 | xargs -0 chmod 777
+    find ${target_dir} -type f -print0 | xargs -0 chmod 666
 }
 
 

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -27,7 +27,7 @@ symlink-public-resources() {
     OVERLAY_DIRECTORY="/fusedoverlay"
     if [ ! -d ${OVERLAY_DIRECTORY} ]; then
         echo "Mounting new tmpfs to ${OVERLAY_DIRECTORY}"
-        mkdir -p /fusedoverlay
+        mkdir -p ${OVERLAY_DIRECTORY}
         mount -t tmpfs tmpfs ${OVERLAY_DIRECTORY}
     fi
     echo "Symlinking - ${public_source_dir} to ${target_dir}"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -1,30 +1,38 @@
 #!/bin/bash
 
 symlink-public-resources() {
+    # This function will "symlink" one read only folder and make it appear
+    # as read write in the target directory. This is used to make gradient
+    # datasets appear in directories with read/write permissions.
+
     public_source_dir=${1}
     target_dir=${2}
-
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    #while [ ! -d "${PUBLIC_DATASET_DIR}/exe_cache" ]
-    while [ ! -d ${public_source_dir} ]
-    do
-        echo "Waiting for dataset "${public_source_dir}" to be mounted..."
-        sleep 1
-    done
-
+    MAX_MOUNT_TIME=60
+    WAITING_FOR=0
+    # while [ ! -d ${public_source_dir} ] && [ "$((${WAITING_FOR}<${MAX_MOUNT_TIME}))" -eq 1 ]
+    # do
+    #     echo "Waiting for dataset "${public_source_dir}" to be mounted..."
+    #     sleep 1
+    # done
+    # To use an overlay mount in a container we need to make sure that the
+    # work and upper directories are not themselves in overlays.
+    OVERLAY_DIRECTORY="/fusedoverlay"
+    if [ ! -d ${OVERLAY_DIRECTORY} ]; then
+        echo "Mounting new tmpfs to ${OVERLAY_DIRECTORY}"
+        mount -t tmpfs tmpfs ${OVERLAY_DIRECTORY}
+    fi
     echo "Symlinking - ${public_source_dir} to ${target_dir}"
 
-    # Make sure it exists otherwise you'll copy your current dir
     mkdir -p ${target_dir}
-    workdir="/fusedoverlay/workdirs/${public_source_dir}"
-    upperdir="/fusedoverlay/upperdir/${public_source_dir}"
+    workdir="${OVERLAY_DIRECTORY}/workdirs/${public_source_dir}"
+    upperdir="${OVERLAY_DIRECTORY}/upperdir/${public_source_dir}"
     mkdir -p ${workdir}
     mkdir -p ${upperdir}
-    fuse-overlayfs -o lowerdir=${public_source_dir},upperdir=${upperdir},workdir=${workdir} ${target_dir}
+    mount -t overlay overlay -o lowerdir=${public_source_dir},upperdir=${upperdir},workdir=${workdir} ${target_dir}
 
 }
-apt update -y
-apt install -y libfuse3-dev fuse-overlayfs
+
 
 echo "Starting preparation of datasets"
 # symlink exe_cache files


### PR DESCRIPTION
This new version of the overlay mounting mechanism includes:

- A time out and clean error out
- Uses kernel space `mount` instead of the user space process `overlayfs`, to achieve that:
  - Mounts a temp file system to hold the upper and work directory
  - Mounts the overlay


Currently this works locally but not on Gradient